### PR TITLE
chore: Upgrade springdoc-openapi version to 2.8.5

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.boot:spring-boot-starter-validation")
 
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 
     // lombok
     compileOnly("org.projectlombok:lombok")


### PR DESCRIPTION
Sloves #51 

When `@RestControllerAdvice` is present, springdoc performs a scanning process for ActiveBean. If the version of `springdoc-openapi` is outdated, it seems to cause compatibility issues with Spring. After upgrading the version of `springdoc-openapi`, Swagger works properly even with `@RestControllerAdvice` in place.



![image](https://github.com/user-attachments/assets/d1cbe570-d27c-4d07-9ee9-faaf6457f733)